### PR TITLE
Update package versions, switch to upstream node-webcrypto-ossl

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,8 +176,8 @@ window.getGuid = require('uuid/v4');
 
 window.addEventListener = Whisper.events.on;
 
-const WebCrypto = require("node-webcrypto-ossl");
-window.crypto = new WebCrypto();
+const { Crypto } = require("node-webcrypto-ossl");
+window.crypto = new Crypto();
 
 window.dcodeIO = {}
 dcodeIO.Long = signalRequire('components/long/dist/Long');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node-persist": "^3.0.5",
     "node-webcrypto-ossl": "^2.0.1",
     "qrcode-terminal": "^0.12.0",
-    "signal-desktop": "witchent/signal-desktop#master",
+    "signal-desktop": "matrix-hacks/signal-desktop#master",
     "underscore": "^1.10.2",
     "worker": "^0.4.0",
     "ws": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "backbone-indexeddb": "^0.0.13",
     "bluebird": "^3.7.2",
     "bytebuffer": "^5.0.1",
-    "electron-builder": "20.39.0",
+    "electron-builder": "22.5.1",
     "indexeddbshim": "^6.1.0",
     "jquery-deferred": "^0.3.1",
     "mkdirp": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -14,20 +14,21 @@
   "dependencies": {
     "backbone": "^1.4.0",
     "backbone-indexeddb": "^0.0.13",
-    "bluebird": "^3.5.5",
+    "bluebird": "^3.7.2",
     "bytebuffer": "^5.0.1",
-    "electron-builder": "20.39.0",
-    "indexeddbshim": "^4.1.0",
+    "electron-builder": "22.4.1",
+    "indexeddbshim": "^6.1.0",
     "jquery-deferred": "^0.3.1",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.4",
     "moment": "^2.24.0",
     "node-persist": "^3.0.5",
-    "node-webcrypto-ossl": "nr23730/node-webcrypto-ossl#73ee251",
+    "node-webcrypto-ossl": "2.0.1",
     "qrcode-terminal": "^0.12.0",
     "signal-desktop": "witchent/signal-desktop#master",
-    "underscore": "^1.9.1",
+    "underscore": "^1.10.2",
     "worker": "^0.4.0",
-    "ws": "^7.1.1",
+    "ws": "^7.2.3",
     "xhr2": "^0.2.0"
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "start": "node run.js"
   },
-  "homepage": "https://github.com/nr23730/node-signal-client",
+  "homepage": "https://github.com/witchent/node-signal-client",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nr23730/node-signal-client.git"
+    "url": "https://github.com/witchent/node-signal-client.git"
   },
   "dependencies": {
     "backbone": "^1.4.0",
@@ -24,7 +24,7 @@
     "node-persist": "^3.0.5",
     "node-webcrypto-ossl": "nr23730/node-webcrypto-ossl#73ee251",
     "qrcode-terminal": "^0.12.0",
-    "signal-desktop": "nr23730/signal-desktop#master",
+    "signal-desktop": "witchent/signal-desktop#master",
     "underscore": "^1.9.1",
     "worker": "^0.4.0",
     "ws": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "start": "node run.js"
   },
-  "homepage": "https://github.com/witchent/node-signal-client",
+  "homepage": "https://github.com/matrix-hacks/node-signal-client",
   "repository": {
     "type": "git",
-    "url": "https://github.com/witchent/node-signal-client.git"
+    "url": "https://github.com/matrix-hacks/node-signal-client.git"
   },
   "dependencies": {
     "backbone": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "mkdirp": "^1.0.4",
     "moment": "^2.24.0",
     "node-persist": "^3.0.5",
-    "node-webcrypto-ossl": "2.0.1",
+    "node-webcrypto-ossl": "nr23730/node-webcrypto-ossl#73ee251",
     "qrcode-terminal": "^0.12.0",
     "signal-desktop": "witchent/signal-desktop#master",
     "underscore": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "backbone-indexeddb": "^0.0.13",
     "bluebird": "^3.7.2",
     "bytebuffer": "^5.0.1",
-    "electron-builder": "22.5.1",
+    "electron-builder": "20.39.0",
     "indexeddbshim": "^6.1.0",
     "jquery-deferred": "^0.3.1",
     "mkdirp": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "mkdirp": "^1.0.4",
     "moment": "^2.24.0",
     "node-persist": "^3.0.5",
-    "node-webcrypto-ossl": "nr23730/node-webcrypto-ossl#73ee251",
+    "node-webcrypto-ossl": "^2.0.1",
     "qrcode-terminal": "^0.12.0",
     "signal-desktop": "witchent/signal-desktop#master",
     "underscore": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "backbone-indexeddb": "^0.0.13",
     "bluebird": "^3.7.2",
     "bytebuffer": "^5.0.1",
-    "electron-builder": "22.4.1",
+    "electron-builder": "22.5.1",
     "indexeddbshim": "^6.1.0",
     "jquery-deferred": "^0.3.1",
     "mkdirp": "^1.0.4",


### PR DESCRIPTION
Updated everything to newest upstream versions.

Switch to node-webcrypto-ossl upstream from fork as upstream now supports aes 256 as well.
Updated index so we can use the upstream version